### PR TITLE
Don't run tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Tests
 on:
   pull_request:
-  push:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
They already run on pull requests, so testing on push is just doubling up.