### PR TITLE
Patch state expectations in all_field and image_preprocessing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.*'
       - run: go generate ./...
       - name: git diff
         run: |

--- a/internal/provider/indices_resource.go
+++ b/internal/provider/indices_resource.go
@@ -566,13 +566,20 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 			}
 		}
 
-		// Ensure features and dependent_fields are always set
-		for i := range newState.Settings.AllFields {
-			if len(newState.Settings.AllFields[i].Features) == 0 {
-				newState.Settings.AllFields[i].Features = nil
-			}
-			if len(newState.Settings.AllFields[i].DependentFields) == 0 {
-				newState.Settings.AllFields[i].DependentFields = nil
+		// marqo doesn't return timeouts, so we maintain the existing state
+		newState.Timeouts = state.Timeouts
+
+		if newState.Settings.AllFields == nil || len(newState.Settings.AllFields) == 0 {
+			newState.Settings.AllFields = nil
+		} else {
+			// Ensure features and dependent_fields are always set
+			for i := range newState.Settings.AllFields {
+				if len(newState.Settings.AllFields[i].Features) == 0 {
+					newState.Settings.AllFields[i].Features = nil
+				}
+				if len(newState.Settings.AllFields[i].DependentFields) == 0 {
+					newState.Settings.AllFields[i].DependentFields = nil
+				}
 			}
 		}
 
@@ -583,9 +590,10 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 			newState.Settings.TreatUrlsAndPointersAsMedia = types.BoolNull()
 		}
 
-		// Handle image_preprocessing.patch_method
-		if newState.Settings.ImagePreprocessing.PatchMethod.ValueString() == "" {
-			newState.Settings.ImagePreprocessing.PatchMethod = types.StringNull()
+		// Handle image_preprocessing
+		if newState.Settings.ImagePreprocessing != nil &&
+			newState.Settings.ImagePreprocessing.PatchMethod.ValueString() == "" {
+			newState.Settings.ImagePreprocessing = nil
 		}
 
 		// preserve the video/audio preprocessing from current state since api does not return them

--- a/internal/provider/indices_resource.go
+++ b/internal/provider/indices_resource.go
@@ -569,8 +569,10 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 		// marqo doesn't return timeouts, so we maintain the existing state
 		newState.Timeouts = state.Timeouts
 
-		if newState.Settings.AllFields == nil || len(newState.Settings.AllFields) == 0 {
+		if state.Settings.AllFields == nil {
 			newState.Settings.AllFields = nil
+		} else if len(newState.Settings.AllFields) == 0 {
+			newState.Settings.AllFields = []AllFieldInput{}
 		} else {
 			// Ensure features and dependent_fields are always set
 			for i := range newState.Settings.AllFields {
@@ -591,9 +593,11 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 
 		// Handle image_preprocessing
-		if newState.Settings.ImagePreprocessing != nil &&
-			newState.Settings.ImagePreprocessing.PatchMethod.ValueString() == "" {
+		if state.Settings.ImagePreprocessing == nil {
 			newState.Settings.ImagePreprocessing = nil
+		} else if newState.Settings.ImagePreprocessing != nil &&
+			newState.Settings.ImagePreprocessing.PatchMethod.ValueString() == "" {
+			newState.Settings.ImagePreprocessing.PatchMethod = types.StringNull()
 		}
 
 		// preserve the video/audio preprocessing from current state since api does not return them
@@ -604,7 +608,7 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 			newState.Settings.AudioPreprocessing = state.Settings.AudioPreprocessing
 		}
 
-		// Then handle zero values (existing code)
+		// Then handle zero values
 		if newState.Settings.VideoPreprocessing != nil &&
 			newState.Settings.VideoPreprocessing.SplitLength.ValueInt64() == 0 &&
 			newState.Settings.VideoPreprocessing.SplitOverlap.ValueInt64() == 0 {


### PR DESCRIPTION
The issue is for `all_fields` and `image_preprocessing`, if users don't set them to 

```
all_fields = [] 
image_preprocessing = {patch_method = null}
``` 
and leave these fields undefined,
then they will get a bad state






