### PR TITLE
Add integration test for minimal config and timeouts and attempt to parallelize tests

### DIFF
--- a/examples/minimal/minimal.tf
+++ b/examples/minimal/minimal.tf
@@ -13,12 +13,12 @@ provider "marqo" {
 }
 
 resource "marqo_index" "example" {
-  index_name = "optional1"
+  index_name = "optional"
   settings = {
     type                 = "unstructured"
     model                = "open_clip/ViT-L-14/laion2b_s32b_b82k"
-    inference_type       = "marqo.GPU"
-    number_of_inferences = 2
+    inference_type       = "marqo.CPU.large"
+    number_of_inferences = 1
     number_of_replicas   = 0
     number_of_shards     = 1
     storage_class        = "marqo.basic"

--- a/internal/provider/indices_datasource_test.go
+++ b/internal/provider/indices_datasource_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccDataSourceIndices(t *testing.T) {
+	t.Parallel()
 	unstructured_index_name := fmt.Sprintf("donotdelete_unstr_dsrc_%s", randomString(7))
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/indices_resource.go
+++ b/internal/provider/indices_resource.go
@@ -177,7 +177,6 @@ func (r *indicesResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 					"vector_numeric_type": schema.StringAttribute{
 						Optional: true,
-						Computed: true,
 					},
 					"number_of_inferences": schema.Int64Attribute{
 						Required: true,
@@ -218,11 +217,9 @@ func (r *indicesResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 					"treat_urls_and_pointers_as_images": schema.BoolAttribute{
 						Optional: true,
-						Computed: true,
 					},
 					"treat_urls_and_pointers_as_media": schema.BoolAttribute{
 						Optional: true,
-						Computed: true,
 					},
 					"model": schema.StringAttribute{
 						Required: true,
@@ -261,7 +258,6 @@ func (r *indicesResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 					"normalize_embeddings": schema.BoolAttribute{
 						Optional: true,
-						Computed: true,
 					},
 					"text_preprocessing": schema.SingleNestedAttribute{
 						Optional: true,
@@ -308,7 +304,6 @@ func (r *indicesResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 					"filter_string_max_length": schema.Int64Attribute{
 						Optional: true,
-						Computed: true,
 					},
 				},
 			},
@@ -608,6 +603,21 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 		if state.Settings.AnnParameters == nil {
 			newState.Settings.AnnParameters = nil
+		}
+		if state.Settings.FilterStringMaxLength.IsNull() {
+			newState.Settings.FilterStringMaxLength = types.Int64Null()
+		}
+		if state.Settings.NormalizeEmbeddings.IsNull() {
+			newState.Settings.NormalizeEmbeddings = types.BoolNull()
+		}
+		if state.Settings.TreatUrlsAndPointersAsImages.IsNull() {
+			newState.Settings.TreatUrlsAndPointersAsImages = types.BoolNull()
+		}
+		if state.Settings.TreatUrlsAndPointersAsMedia.IsNull() {
+			newState.Settings.TreatUrlsAndPointersAsMedia = types.BoolNull()
+		}
+		if state.Settings.VectorNumericType.IsNull() {
+			newState.Settings.VectorNumericType = types.StringNull()
 		}
 
 		// Ignore these fields for structured indexes


### PR DESCRIPTION
Add minimal configuration (with only required fields) in the integration tests alongside testing timeouts. Attempt to parallelize acceptance tests,