### PR TITLE
Adding collapseFields and tests

### DIFF
--- a/docs/data-sources/read_indices.md
+++ b/docs/data-sources/read_indices.md
@@ -31,6 +31,7 @@ Optional:
 
 - `all_fields` (Attributes List) (see [below for nested schema](#nestedatt--items--all_fields))
 - `audio_preprocessing` (Attributes) (see [below for nested schema](#nestedatt--items--audio_preprocessing))
+- `collapse_fields` (Attributes List) (see [below for nested schema](#nestedatt--items--collapse_fields))
 - `model_properties` (Attributes) (see [below for nested schema](#nestedatt--items--model_properties))
 - `tensor_fields` (List of String)
 - `video_preprocessing` (Attributes) (see [below for nested schema](#nestedatt--items--video_preprocessing))
@@ -80,6 +81,18 @@ Optional:
 
 - `split_length` (String)
 - `split_overlap` (String)
+
+
+<a id="nestedatt--items--collapse_fields"></a>
+### Nested Schema for `items.collapse_fields`
+
+Optional:
+
+- `min_groups` (Number) The minimum number of groups for the collapse field
+
+Read-Only:
+
+- `name` (String) The name of the collapse field
 
 
 <a id="nestedatt--items--model_properties"></a>

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -46,6 +46,7 @@ Optional:
 - `all_fields` (Attributes List) (see [below for nested schema](#nestedatt--settings--all_fields))
 - `ann_parameters` (Attributes) (see [below for nested schema](#nestedatt--settings--ann_parameters))
 - `audio_preprocessing` (Attributes) (see [below for nested schema](#nestedatt--settings--audio_preprocessing))
+- `collapse_fields` (Attributes List) (see [below for nested schema](#nestedatt--settings--collapse_fields))
 - `filter_string_max_length` (Number)
 - `image_preprocessing` (Attributes) (see [below for nested schema](#nestedatt--settings--image_preprocessing))
 - `model_properties` (Attributes) (see [below for nested schema](#nestedatt--settings--model_properties))
@@ -93,6 +94,15 @@ Optional:
 
 - `split_length` (Number)
 - `split_overlap` (Number)
+
+
+<a id="nestedatt--settings--collapse_fields"></a>
+### Nested Schema for `settings.collapse_fields`
+
+Optional:
+
+- `min_groups` (Number)
+- `name` (String)
 
 
 <a id="nestedatt--settings--image_preprocessing"></a>

--- a/examples/create_index_collapse_fields/create_index_collapse_fields.tf
+++ b/examples/create_index_collapse_fields/create_index_collapse_fields.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    marqo = {
+      source = "registry.terraform.io/marqo/marqo"
+    }
+  }
+}
+
+provider "marqo" {
+  host    = "https://api.marqo.ai/api/v2"
+  api_key = var.marqo_api_key
+}
+
+resource "marqo_index" "c_f_test" {
+		index_name = "%s"
+		timeouts = {
+			create = "60m"
+			update = "60m"
+			delete = "45m"
+		}
+		settings = {
+			type = "unstructured"
+			model = "open_clip/ViT-L-14/laion2b_s32b_b82k"
+			inference_type = "marqo.CPU.large"
+			number_of_inferences = 1
+			number_of_replicas = 0
+			number_of_shards = 1
+			storage_class = "marqo.basic"
+			collapse_fields = [
+				{
+					name = "product_family_2"
+					min_groups = 200
+				}
+			]
+		}
+	}
+
+output "created_index" {
+  value = marqo_index.example
+}
+
+variable "marqo_api_key" {
+  type        = string
+  description = "Marqo API key"
+}

--- a/examples/create_index_collapse_fields/create_index_collapse_fields.tf
+++ b/examples/create_index_collapse_fields/create_index_collapse_fields.tf
@@ -12,28 +12,28 @@ provider "marqo" {
 }
 
 resource "marqo_index" "c_f_test" {
-		index_name = "%s"
-		timeouts = {
-			create = "60m"
-			update = "60m"
-			delete = "45m"
-		}
-		settings = {
-			type = "unstructured"
-			model = "open_clip/ViT-L-14/laion2b_s32b_b82k"
-			inference_type = "marqo.CPU.large"
-			number_of_inferences = 1
-			number_of_replicas = 0
-			number_of_shards = 1
-			storage_class = "marqo.basic"
-			collapse_fields = [
-				{
-					name = "product_family_2"
-					min_groups = 200
-				}
-			]
-		}
-	}
+  index_name = "%s"
+  timeouts = {
+    create = "60m"
+    update = "60m"
+    delete = "45m"
+  }
+  settings = {
+    type                 = "unstructured"
+    model                = "open_clip/ViT-L-14/laion2b_s32b_b82k"
+    inference_type       = "marqo.CPU.large"
+    number_of_inferences = 1
+    number_of_replicas   = 0
+    number_of_shards     = 1
+    storage_class        = "marqo.basic"
+    collapse_fields = [
+      {
+        name       = "product_family_2"
+        min_groups = 200
+      }
+    ]
+  }
+}
 
 output "created_index" {
   value = marqo_index.example

--- a/go_marqo/client.go
+++ b/go_marqo/client.go
@@ -51,6 +51,7 @@ type IndexDetail struct {
 	AnnParameters                AnnParameters           `json:"annParameters"`
 	MarqoVersion                 string                  `json:"marqoVersion"`
 	FilterStringMaxLength        int64                   `json:"filterStringMaxLength"`
+	CollapseFields               []CollapseFieldInput    `json:"collapseFields"`
 }
 
 type AllFieldInput struct {
@@ -58,6 +59,11 @@ type AllFieldInput struct {
 	Type            string             `tfsdk:"type"`
 	Features        []string           `tfsdk:"features"`
 	DependentFields map[string]float64 `tfsdk:"dependentFields"`
+}
+
+type CollapseFieldInput struct {
+	Name      string `json:"name"`
+	MinGroups int64  `json:"minGroups"`
 }
 
 type ModelProperties struct {
@@ -149,6 +155,7 @@ type IndexSettings struct {
 	NumberOfReplicas             int64                   `json:"numberOfReplicas"`
 	TreatUrlsAndPointersAsImages bool                    `json:"treatUrlsAndPointersAsImages"`
 	FilterStringMaxLength        int64                   `json:"filterStringMaxLength"`
+	CollapseFields               []CollapseFieldInput    `json:"collapseFields"`
 }
 
 // NewClient creates and returns a new API client or an error.

--- a/internal/provider/indices_datasource.go
+++ b/internal/provider/indices_datasource.go
@@ -623,9 +623,15 @@ func (d *indicesDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		if len(indexDetail.CollapseFields) > 0 {
 			collapseFields := make([]CollapseFieldInput, len(indexDetail.CollapseFields))
 			for j, field := range indexDetail.CollapseFields {
+				var minGroupsValue types.Int64
+				if field.MinGroups == 0 {
+					minGroupsValue = types.Int64Null()
+				} else {
+					minGroupsValue = types.Int64Value(field.MinGroups)
+				}
 				collapseFields[j] = CollapseFieldInput{
 					Name:      types.StringValue(field.Name),
-					MinGroups: types.Int64Value(field.MinGroups),
+					MinGroups: minGroupsValue,
 				}
 			}
 			items[i].CollapseFields = collapseFields

--- a/internal/provider/indices_datasource.go
+++ b/internal/provider/indices_datasource.go
@@ -62,6 +62,7 @@ type indexModel struct {
 	AnnParameters                *AnnParametersModel      `tfsdk:"ann_parameters"`
 	MarqoVersion                 types.String             `tfsdk:"marqo_version"`
 	FilterStringMaxLength        types.String             `tfsdk:"filter_string_max_length"`
+	CollapseFields               []CollapseFieldInput     `tfsdk:"collapse_fields"`
 }
 
 type ModelPropertiesModel struct {
@@ -370,6 +371,23 @@ func (d *indicesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 								},
 							},
 						},
+						"collapse_fields": schema.ListNestedAttribute{
+							Computed: true,
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"name": schema.StringAttribute{
+										Computed:    true,
+										Description: "The name of the collapse field",
+									},
+									"min_groups": schema.Int64Attribute{
+										Computed:    true,
+										Optional:    true,
+										Description: "The minimum number of groups for the collapse field",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -600,6 +618,20 @@ func (d *indicesDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		// Remove null fields
 		if items[i].InferenceType.IsNull() {
 			items[i].InferenceType = types.StringNull()
+		}
+
+		if len(indexDetail.CollapseFields) > 0 {
+			collapseFields := make([]CollapseFieldInput, len(indexDetail.CollapseFields))
+			for j, field := range indexDetail.CollapseFields {
+				collapseFields[j] = CollapseFieldInput{
+					Name:      types.StringValue(field.Name),
+					MinGroups: types.Int64Value(field.MinGroups),
+				}
+			}
+			items[i].CollapseFields = collapseFields
+		} else {
+			// Set to empty slice instead of nil
+			items[i].CollapseFields = []CollapseFieldInput{}
 		}
 	}
 

--- a/internal/provider/indices_resource.go
+++ b/internal/provider/indices_resource.go
@@ -617,8 +617,8 @@ func (r *indicesResource) findAndCreateState(indices []go_marqo.IndexDetail, ind
 			if len(indexDetail.CollapseFields) > 0 {
 				var collapseFields []CollapseFieldInput
 				for _, field := range indexDetail.CollapseFields {
-					// If MinGroups is 0 in the API response, set it to null
-					// This will preserve the value from the configuration
+					// This handles undefined Go integers being assigned a value of zero. We want to omit the field in this case.
+					// Zero min_groups is invalid in Marqo, so we can safely assume that a zero value means the field was not set.
 					minGroups := field.MinGroups
 					var minGroupsValue types.Int64
 					if minGroups == 0 {

--- a/internal/provider/indices_resource.go
+++ b/internal/provider/indices_resource.go
@@ -66,6 +66,7 @@ type IndexSettingsModel struct {
 	AudioPreprocessing           *AudioPreprocessingModelCreate `tfsdk:"audio_preprocessing"`
 	AnnParameters                *AnnParametersModelCreate      `tfsdk:"ann_parameters"`
 	FilterStringMaxLength        types.Int64                    `tfsdk:"filter_string_max_length"`
+	CollapseFields               []CollapseFieldInput           `tfsdk:"collapse_fields"`
 }
 
 type ModelPropertiesModelCreate struct {
@@ -84,6 +85,11 @@ type AllFieldInput struct {
 	Type            types.String             `tfsdk:"type"`
 	Features        []types.String           `tfsdk:"features"`
 	DependentFields map[string]types.Float64 `tfsdk:"dependent_fields"`
+}
+
+type CollapseFieldInput struct {
+	Name      types.String `tfsdk:"name"`
+	MinGroups types.Int64  `tfsdk:"min_groups"`
 }
 
 type TextPreprocessingModelCreate struct {
@@ -305,6 +311,15 @@ func (r *indicesResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 					"filter_string_max_length": schema.Int64Attribute{
 						Optional: true,
+					},
+					"collapse_fields": schema.ListNestedAttribute{
+						Optional: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"name":       schema.StringAttribute{Optional: true},
+								"min_groups": schema.Int64Attribute{Optional: true},
+							},
+						},
 					},
 				},
 			},
@@ -598,6 +613,28 @@ func (r *indicesResource) findAndCreateState(indices []go_marqo.IndexDetail, ind
 				model.Settings.AnnParameters = nil
 			}
 
+			// Handle CollapseFields
+			if len(indexDetail.CollapseFields) > 0 {
+				var collapseFields []CollapseFieldInput
+				for _, field := range indexDetail.CollapseFields {
+					// If MinGroups is 0 in the API response, set it to null
+					// This will preserve the value from the configuration
+					minGroups := field.MinGroups
+					var minGroupsValue types.Int64
+					if minGroups == 0 {
+						minGroupsValue = types.Int64Null()
+					} else {
+						minGroupsValue = types.Int64Value(minGroups)
+					}
+
+					collapseFields = append(collapseFields, CollapseFieldInput{
+						Name:      types.StringValue(field.Name),
+						MinGroups: minGroupsValue,
+					})
+				}
+				model.Settings.CollapseFields = collapseFields
+			}
+
 			return model, true
 		}
 	}
@@ -851,6 +888,7 @@ func (r *indicesResource) Read(ctx context.Context, req resource.ReadRequest, re
 		if newState.Settings.InferenceType.IsNull() {
 			newState.Settings.InferenceType = types.StringNull()
 		}
+
 	}
 
 	// if index no longer exists in cloud, delete the state
@@ -1087,6 +1125,21 @@ func (r *indicesResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	if len(model.Settings.CollapseFields) > 0 {
+		collapseFieldsList := make([]map[string]interface{}, len(model.Settings.CollapseFields))
+		for i, field := range model.Settings.CollapseFields {
+			collapseField := map[string]interface{}{
+				"name": field.Name.ValueString(),
+			}
+			// Only include minGroups if it's explicitly set
+			if !field.MinGroups.IsNull() && !field.MinGroups.IsUnknown() {
+				collapseField["minGroups"] = field.MinGroups.ValueInt64()
+			}
+			collapseFieldsList[i] = collapseField
+		}
+		settings["collapseFields"] = collapseFieldsList
+	}
+
 	// Remove optional fields if they are not set
 	if model.Settings.TreatUrlsAndPointersAsImages.IsNull() {
 		delete(settings, "treatUrlsAndPointersAsImages")
@@ -1147,6 +1200,9 @@ func (r *indicesResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 	if model.Settings.FilterStringMaxLength.IsNull() || model.Settings.FilterStringMaxLength.IsUnknown() {
 		delete(settings, "filterStringMaxLength")
+	}
+	if len(model.Settings.CollapseFields) == 0 {
+		delete(settings, "collapseFields")
 	}
 
 	tflog.Debug(ctx, "Creating index with settings: %#v", settings)
@@ -1414,6 +1470,14 @@ func (r *indicesResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError(
 			"Cannot Modify Model Properties",
 			"The model_properties configuration cannot be modified. You must destroy and recreate the index to change this field.")
+		return
+	}
+
+	if !reflect.DeepEqual(model.Settings.CollapseFields, state.Settings.CollapseFields) {
+		resp.Diagnostics.AddError(
+			"Cannot Modify Index Collapse Fields",
+			"The collapse_fields setting cannot be modified after index creation. To change it, you must recreate the index.",
+		)
 		return
 	}
 

--- a/internal/provider/indices_resource_test.go
+++ b/internal/provider/indices_resource_test.go
@@ -1024,3 +1024,157 @@ func testAccResourceMaximalIndexConfigUpdated(name string) string {
 		}
 	`, name)
 }
+
+func TestAccResourceWithCollapseFields(t *testing.T) {
+	testIndexName := "test_collapse_fields_index"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Delete if exists
+			{
+				Config: testAccEmptyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIndexExistsAndDelete(testIndexName),
+				),
+			},
+			// Create with collapse fields
+			{
+				Config: testAccResourceIndexWithCollapseFieldsConfig(testIndexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("marqo_index.test", "index_name", testIndexName),
+					resource.TestCheckResourceAttr("marqo_index.test", "settings.collapse_fields.#", "1"),
+					resource.TestCheckResourceAttr("marqo_index.test", "settings.collapse_fields.0.name", "product_family"),
+					testAccCheckIndexIsReady(testIndexName),
+				),
+			},
+			// Update collapse fields
+			{
+				Config:      testAccResourceIndexUpdateWithCollapseFieldsConfig(testIndexName),
+				ExpectError: regexp.MustCompile("Cannot Modify Index Collapse Fields"),
+			},
+		},
+	})
+}
+
+func testAccResourceIndexWithCollapseFieldsConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "marqo_index" "test" {
+		index_name = "%s"
+		timeouts = {
+			create = "60m"
+			update = "60m"
+			delete = "45m"
+		}
+		settings = {
+			type = "unstructured"
+			model = "open_clip/ViT-L-14/laion2b_s32b_b82k"
+			inference_type = "marqo.CPU.large"
+			number_of_inferences = 1
+			number_of_replicas = 0
+			number_of_shards = 1
+			storage_class = "marqo.basic"
+			collapse_fields = [
+				{
+					name = "product_family"
+					min_groups = 100
+				}
+			]
+		}
+	}
+		`, name)
+}
+
+func testAccResourceIndexUpdateWithCollapseFieldsConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "marqo_index" "test" {
+		index_name = "%s"
+		timeouts = {
+			create = "60m"
+			update = "60m"
+			delete = "45m"
+		}
+		settings = {
+			type = "unstructured"
+			model = "open_clip/ViT-L-14/laion2b_s32b_b82k"
+			inference_type = "marqo.CPU.large"
+			number_of_inferences = 1
+			number_of_replicas = 0
+			number_of_shards = 1
+			storage_class = "marqo.basic"
+			collapse_fields = [
+				{
+					name = "product_family_2"
+					min_groups = 200
+				}
+			]
+		}
+	}
+		`, name)
+}
+
+func TestAccResourceWithOptionalCollapseFieldsMinGroups(t *testing.T) {
+	testIndexName := "test_collapse_fields_optional"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Delete if exists
+			{
+				Config: testAccEmptyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIndexExistsAndDelete(testIndexName),
+				),
+			},
+			// Create with collapse fields but no min_groups
+			{
+				Config: testAccResourceIndexWithOptionalCollapseFieldsConfig(testIndexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("marqo_index.test", "index_name", testIndexName),
+					resource.TestCheckResourceAttr("marqo_index.test", "settings.collapse_fields.#", "1"),
+					resource.TestCheckResourceAttr("marqo_index.test", "settings.collapse_fields.0.name", "product_family"),
+					// Don't check min_groups since we expect it to be null
+					testAccCheckIndexIsReady(testIndexName),
+				),
+			},
+			// Import testing to verify state consistency
+			{
+				ResourceName:                         "marqo_index.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        testIndexName,
+				ImportStateVerifyIdentifierAttribute: "index_name",
+				ImportStateVerifyIgnore:              []string{"timeouts"},
+			},
+		},
+	})
+}
+
+func testAccResourceIndexWithOptionalCollapseFieldsConfig(name string) string {
+	return fmt.Sprintf(`
+    resource "marqo_index" "test" {
+        index_name = "%s"
+        timeouts = {
+            create = "60m"
+            update = "60m"
+            delete = "45m"
+        }
+        settings = {
+            type = "unstructured"
+            model = "open_clip/ViT-L-14/laion2b_s32b_b82k"
+            inference_type = "marqo.CPU.large"
+            number_of_inferences = 1
+            number_of_replicas = 0
+            number_of_shards = 1
+            storage_class = "marqo.basic"
+            collapse_fields = [
+                {
+                    name = "product_family"
+                }
+            ]
+        }
+    }
+        `, name)
+}


### PR DESCRIPTION
Adding collapseField functionality to the Marqo Terraform Provider. 
Adding tests tests for index creation with collapseFields and immutability on subsequent update attempts.